### PR TITLE
feat: more than one model per species

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,5 @@ web:
     - PYTHONASYNCIODEBUG=1
     - ILOOP_TOKEN
     - ILOOP_API
-    - MODEL_API=https://api.dd-decaf.eu/models/
+    - MODEL_API=https://api.dd-decaf.eu
   command: ["-w", "1", "-b", "0.0.0.0:7000", "-t", "150", "-k", "aiohttp.worker.GunicornWebWorker", "iloop_to_model.app:app"]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -9,13 +9,16 @@ class TestUM:
         self.iloop = iloop_client(Default.ILOOP_API, Default.ILOOP_TOKEN)
         self.experiment = self.iloop.Experiment.instances(where={'type': 'fermentation'})[0]
         self.sample = self.experiment.read_samples()[0]
+        self.model = {'ECO': 'iJO1366', 'SCE': 'iMM904'}[self.sample.strain.organism.short_code]
 
     def test_request(self):
         URLS = [
+            '/samples/{}/maximum-yield?model-id={}'.format(self.sample.id, self.model),
             '/samples/{}/maximum-yield'.format(self.sample.id),
             '/samples/{}/model?phase-id=1&with-fluxes=1&method=room'.format(self.sample.id),
             '/samples/{}/fluxes'.format(self.sample.id),
             '/samples/{}/phases'.format(self.sample.id),
+            '/samples/{}/model-options'.format(self.sample.id),
         ]
         for url in URLS:
             r = requests.get(self.api + url)


### PR DESCRIPTION
Support having more than one model per species by adding the optional
`model_id` parameter and using the `model-options` function to get
defaults.

The dict of models per species here is now just the default model and the one used unless request explicitly says which model to use.