### PR TITLE
Add Sentry integration

### DIFF
--- a/iloop_to_model/__init__.py
+++ b/iloop_to_model/__init__.py
@@ -5,10 +5,22 @@ from functools import lru_cache
 import requests
 from potion_client import Client
 from potion_client.auth import HTTPBearerAuth
+from raven import Client as RavenClient
+from raven.conf import setup_logging
+from raven.handlers.logging import SentryHandler
+
+from . import settings
+
 
 logger = logging.getLogger('iloop-to-model')
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))  # Logspout captures logs from stdout if docker containers
 logger.setLevel(logging.DEBUG)
+
+# Configure Raven to capture warning logs
+raven_client = RavenClient(settings.Default.SENTRY_DSN)
+handler = SentryHandler(raven_client)
+handler.setLevel(logging.WARNING)
+setup_logging(handler)
 
 
 @lru_cache(128)

--- a/iloop_to_model/app.py
+++ b/iloop_to_model/app.py
@@ -2,6 +2,7 @@ import asyncio
 from itertools import groupby
 from collections import namedtuple
 
+from aiohttp import web
 import aiohttp_cors
 from venom.rpc import Service, Venom
 from venom.rpc.comms.aiohttp import create_app
@@ -14,6 +15,7 @@ from iloop_to_model.iloop_to_model import (
     model_options_for_samples,
     phases_for_samples, scalars_by_phases, theoretical_maximum_yield_for_phase,
     ILOOP_SPECIES_TO_TAXON)
+from iloop_to_model.middleware import raven_middleware
 from iloop_to_model.settings import Default
 from iloop_to_model.stubs import *
 
@@ -261,7 +263,7 @@ venom.add(ExperimentsService)
 venom.add(SamplesService)
 venom.add(DataAdjustedService)
 venom.add(ReflectService)
-app = create_app(venom)
+app = create_app(venom, web.Application(middlewares=[raven_middleware]))
 # Configure default CORS settings.
 cors = aiohttp_cors.setup(app, defaults={
     "*": aiohttp_cors.ResourceOptions(

--- a/iloop_to_model/middleware.py
+++ b/iloop_to_model/middleware.py
@@ -1,0 +1,12 @@
+from . import raven_client
+
+
+async def raven_middleware(app, handler):
+    """aiohttp middleware which captures any uncaught exceptions to Sentry before re-raising"""
+    async def middleware_handler(request):
+        try:
+            return await handler(request)
+        except Exception:
+            raven_client.captureException()
+            raise
+    return middleware_handler

--- a/iloop_to_model/settings.py
+++ b/iloop_to_model/settings.py
@@ -14,6 +14,7 @@ class Default(object):
 
     ILOOP_API = os.environ['ILOOP_API']
     ILOOP_TOKEN = os.environ['ILOOP_TOKEN']
+    SENTRY_DSN = os.environ.get('SENTRY_DSN', '')
 
     REDIRECTS = {
         'iloop.biosustain.dtu.dk': 'https://iloop.biosustain.dtu.dk/api',

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest
 pytest-asyncio==0.5.0
 pytest-cov==2.4.0
 https://github.com/biosustain/venom/archive/feat/json.zip
+raven==6.4.0


### PR DESCRIPTION
Adds Raven to capture error events to Sentry

- aiohttp middleware logs uncaught exceptions, and re-raises
- log events of `warning` or higher level