### PR TITLE
Remove venom workaround

### DIFF
--- a/iloop_to_model/app.py
+++ b/iloop_to_model/app.py
@@ -253,8 +253,7 @@ class DataAdjustedService(Service):
         return ModelsMessage(response={k: ModelMessage(
             model=JSONValue(v['model']),
             model_id=v['model_id'],
-            # if the growth rate is 0.0, venom detects the field as undefined
-            growth_rate=v['growth-rate'] + 1e-106,
+            growth_rate=v['growth-rate'],
             fluxes=v.get('fluxes')
         ) for k, v in result.items()})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ uvloop
 pytest
 pytest-asyncio==0.5.0
 pytest-cov==2.4.0
-https://github.com/biosustain/venom/archive/feat/json.zip
+venom==2.0.0
 raven==6.4.0


### PR DESCRIPTION
[Fixed in venom master](https://github.com/biosustain/venom/pull/27). The `feat/json` branch is also merged to master so it should be safe to upgrade.

Note that we should also retrieve venom from pypi, ref this warning from pip install:

    Collecting https://github.com/biosustain/venom/archive/master.zip (from -r /tmp/requirements.txt (line 14))
      Downloading https://github.com/biosustain/venom/archive/master.zip
      DEPRECATION: Dependency Links processing has been deprecated and will be removed in a future release.