### PR TITLE
Verify HTTPS connections

### DIFF
--- a/iloop_to_model/__init__.py
+++ b/iloop_to_model/__init__.py
@@ -38,9 +38,7 @@ setup_logging(handler)
 
 @lru_cache(128)
 def iloop_client(api, token):
-    requests.packages.urllib3.disable_warnings()
     return Client(
         api,
         auth=HTTPBearerAuth(token),
-        verify=False
     )


### PR DESCRIPTION
There is no apparent reason TLS connections shouldn't be properly verified (especially now that our certificate has an A rating!). Note that for local connections to iloop, `data.dd-decaf.eu` must be used and not `iloop.dd-decaf.eu`.