### PR TITLE
Add code style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# Editor Configuration (http://editorconfig.org)
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py, pyi}]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - make start
   
 script:
-  - make test
+  - make qa
   - docker-compose logs
   - ./scripts/verify_license_headers.sh iloop_to_model tests
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
 script:
   - make qa
   - docker-compose logs
-  - ./scripts/verify_license_headers.sh iloop_to_model tests
 
 after_success:
   - docker-compose exec web /bin/bash -c "codecov --token $CODECOV_TOKEN"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ before_install:
 
 install:
   - make start
-  
+
 script:
   - make qa
   - docker-compose logs
   - ./scripts/verify_license_headers.sh iloop_to_model tests
-  
+
 after_success:
   - docker-compose exec web /bin/bash -c "codecov --token $CODECOV_TOKEN"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM python:3.6-slim
+
+ENV PYTHONUNBUFFERED 1
+
 RUN apt-get update \
     && apt-get install -y gcc && apt-get install -y build-essential python-dev
 RUN apt-get update && apt-get -y upgrade && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,4 @@ WORKDIR iloop-to-model
 
 ENV PYTHONPATH $PYTHONPATH:/iloop-to-model
 
-ENTRYPOINT ["gunicorn"]
-CMD ["-w", "4", "-b", "0.0.0.0:7000", "-t", "150", "-k", "aiohttp.worker.GunicornWebWorker", "iloop_to_model.app:app"]
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:7000", "-t", "150", "-k", "aiohttp.worker.GunicornWebWorker", "iloop_to_model.app:app"]

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ start:
 	docker network inspect iloop || docker network create iloop
 	docker-compose up -d --build
 
+## Run all QA targets
+.PHONY: qa
+qa: test flake8 isort license
 
 ## Run the tests
 test: start
@@ -23,6 +26,20 @@ test: start
 	@echo "* Running tests."
 	@echo "**********************************************************************"
 	docker-compose exec web /bin/bash -c "py.test -vxs --cov=./iloop_to_model tests/"
+
+## Run flake8
+.PHONY: flake8
+flake8:
+	docker-compose run --rm web flake8 iloop_to_model tests
+
+## Check import sorting
+.PHONY: isort
+isort:
+	docker-compose run --rm web isort --check-only --recursive iloop_to_model tests
+
+## Sort imports and write changes to files
+isort-save:
+	docker-compose run --rm web isort --recursive iloop_to_model tests
 
 ## Verify license headers in source files
 license:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: start test license stop clean
+.PHONY: start qa test flake8 isort isort-save license stop clean logs
 
 #################################################################################
 # GLOBALS                                                                       #
@@ -17,7 +17,6 @@ start:
 	docker-compose up -d --build
 
 ## Run all QA targets
-.PHONY: qa
 qa: test flake8 isort license
 
 ## Run the tests
@@ -28,12 +27,10 @@ test: start
 	docker-compose exec web /bin/bash -c "py.test -vxs --cov=./iloop_to_model tests/"
 
 ## Run flake8
-.PHONY: flake8
 flake8:
 	docker-compose run --rm web flake8 iloop_to_model tests
 
 ## Check import sorting
-.PHONY: isort
 isort:
 	docker-compose run --rm web isort --check-only --recursive iloop_to_model tests
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/DD-DeCaF/iloop-to-model.svg?branch=master)](https://travis-ci.org/DD-DeCaF/iloop-to-model)
 [![Codecov](https://codecov.io/gh/DD-DeCaF/iloop-to-model/branch/master/graph/badge.svg)](https://codecov.io/gh/DD-DeCaF/iloop-to-model)
+[![Requirements Status](https://requires.io/github/DD-DeCaF/iloop-to-model/requirements.svg?branch=master)](https://requires.io/github/DD-DeCaF/iloop-to-model/requirements/?branch=master)
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ILOOP_TOKEN
       - ILOOP_API=${ILOOP_API:-http://iloop-backend:80/api}
       - MODEL_API=${MODEL_API:-http://model-backend:8000}
-    command: ["-w", "1", "-b", "0.0.0.0:7000", "-t", "150", "-k", "aiohttp.worker.GunicornWebWorker", "--reload", "iloop_to_model.app:app"]
+    command: ["gunicorn", "-w", "1", "-b", "0.0.0.0:7000", "-t", "150", "-k", "aiohttp.worker.GunicornWebWorker", "--reload", "iloop_to_model.app:app"]
     networks:
       iloop:
         aliases:

--- a/iloop_to_model/app.py
+++ b/iloop_to_model/app.py
@@ -145,7 +145,7 @@ class ExperimentsService(Service):
         iloop = iloop_from_context(self.context)
         experiments = [e for e in iloop.Experiment.instances(where=dict(type='fermentation')) if
                        request.taxon_code in {ILOOP_SPECIES_TO_TAXON[s.strain.organism.short_code] for s in
-                                                 e.read_samples()}]
+                       e.read_samples()}]
         return ExperimentsMessage([ExperimentMessage(id=experiment.id, name=experiment.identifier)
                                    for experiment in experiments])
 

--- a/iloop_to_model/app.py
+++ b/iloop_to_model/app.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import asyncio
-from itertools import groupby
 from collections import namedtuple
+from itertools import groupby
 
-from aiohttp import web
 import aiohttp_cors
+from aiohttp import web
 from venom.rpc import Service, Venom
 from venom.rpc.comms.aiohttp import create_app
 from venom.rpc.method import http
@@ -25,13 +25,12 @@ from venom.rpc.reflect.service import ReflectService
 
 from iloop_to_model import iloop_client, logger
 from iloop_to_model.iloop_to_model import (
-    fluxes_for_phase, gather_for_phases, info_for_samples, model_for_phase,
-    model_options_for_samples,
-    phases_for_samples, scalars_by_phases, theoretical_maximum_yield_for_phase,
-    ILOOP_SPECIES_TO_TAXON)
+    ILOOP_SPECIES_TO_TAXON, fluxes_for_phase, gather_for_phases, info_for_samples, model_for_phase,
+    model_options_for_samples, phases_for_samples, scalars_by_phases, theoretical_maximum_yield_for_phase)
 from iloop_to_model.middleware import raven_middleware
 from iloop_to_model.settings import Default
 from iloop_to_model.stubs import *
+
 
 NamedSample = namedtuple('NamedSample', 'pool medium feed_medium operation')
 

--- a/iloop_to_model/app.py
+++ b/iloop_to_model/app.py
@@ -29,7 +29,12 @@ from iloop_to_model.iloop_to_model import (
     model_options_for_samples, phases_for_samples, scalars_by_phases, theoretical_maximum_yield_for_phase)
 from iloop_to_model.middleware import raven_middleware
 from iloop_to_model.settings import Default
-from iloop_to_model.stubs import *
+from iloop_to_model.stubs import (
+    CurrentOrganismsMessage, ExperimentMessage, ExperimentsMessage, ExperimentsRequestMessage, JSONValue,
+    MaximumYieldMessage, MaximumYieldsMessage, MeasurementMessage, MetaboliteMediumMessage, MetabolitePhasePlaneMessage,
+    ModelMessage, ModelRequestMessage, ModelsMessage, OrganismToTaxonMessage, PhaseMessage, PhasePlaneMessage,
+    PhasePlanesMessage, PhasesMessage, SampleInfoMessage, SampleMessage, SampleModelsMessage, SamplesInfoMessage,
+    SamplesMessage, SamplesRequestMessage)
 
 
 NamedSample = namedtuple('NamedSample', 'pool medium feed_medium operation')

--- a/iloop_to_model/iloop_to_model.py
+++ b/iloop_to_model/iloop_to_model.py
@@ -331,13 +331,13 @@ def tmy_to_dict(data):
     # TODO: replace with compatible message from the model service
     if not data:
         return data
-    u, l = 'objective_upper_bound', 'objective_lower_bound'
-    o = list(set(data.keys()) - {u, l})[0]
+    upper, lower = 'objective_upper_bound', 'objective_lower_bound'
+    objective = list(set(data.keys()) - {upper, lower})[0]
     return dict(
-        objective_upper_bound=data[u],
-        objective_lower_bound=data[l],
-        objective=data[o],
-        objective_id=o,
+        objective_upper_bound=data[upper],
+        objective_lower_bound=data[lower],
+        objective=data[objective],
+        objective_id=objective,
     )
 
 

--- a/iloop_to_model/stubs.py
+++ b/iloop_to_model/stubs.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from venom.fields import MapField, Int, String, repeated, map_, Float32, Bool
-from venom.message import Message
 from venom.common.messages import JSONValue
+from venom.fields import Bool, Float32, Int, MapField, String, map_, repeated
+from venom.message import Message
 
 
 class OrganismToTaxonMessage(Message):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,13 @@ redis
 codecov
 gunicorn
 uvloop
+venom==2.0.0
+raven==6.4.0
+
+# Testing and QA
+flake8
 pytest
 pytest-asyncio==0.5.0
 pytest-cov==2.4.0
-venom==2.0.0
-raven==6.4.0
+codecov
+isort

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ codecov
 gunicorn
 uvloop
 venom==2.0.0
-raven==6.4.0
+raven>=6.6.0,<6.7
 
 # Testing and QA
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ raven==6.4.0
 # Testing and QA
 flake8
 pytest
-pytest-asyncio==0.5.0
-pytest-cov==2.4.0
+pytest-asyncio
+pytest-cov
 codecov
 isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,16 @@
-[pycodestyle]
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"
+
+[wheel]
+universal = 1
+
+[flake8]
 max-line-length = 120
 exclude = __init__.py,docs
 
@@ -6,13 +18,10 @@ exclude = __init__.py,docs
 test = pytest
 
 [tool:pytest]
-testpaths = test
+testpaths = tests
 
 [isort]
-not_skip = __init__.py
-indent = 4
 line_length = 120
+indent = 4
 multi_line_output = 4
-known_third_party = future,six
-known_first_party = iloop_to_model
-
+lines_after_imports = 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ replace = version="{new_version}"
 universal = 1
 
 [flake8]
+# Note: Line length of 120 is an exception to the code style guidelines
 max-line-length = 120
 exclude = __init__.py,docs
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -15,8 +15,8 @@
 import requests
 
 from iloop_to_model import iloop_client
-from iloop_to_model.settings import Default
 from iloop_to_model.iloop_to_model import ILOOP_SPECIES_TO_TAXON
+from iloop_to_model.settings import Default
 
 
 class TestUM:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -16,11 +16,10 @@ from collections import namedtuple
 
 import pytest
 
-from iloop_to_model.iloop_to_model import (
-    MEASUREMENTS, MEDIUM, extract_genotype_changes, message_for_adjust, phases_for_samples, scalars_by_phases,
-
-)
 from iloop_to_model.app import name_groups
+from iloop_to_model.iloop_to_model import (
+    MEASUREMENTS, MEDIUM, extract_genotype_changes, message_for_adjust, phases_for_samples, scalars_by_phases)
+
 
 Sample = namedtuple('Sample',
                     ['id', 'strain', 'medium', 'feed_medium', 'read_scalars', 'name', 'read_xref_measurements',


### PR DESCRIPTION
* Adds the .editorconfig and setup.cfg from biosustain and decaf style guides
* Follows the rules 🚓 
    * Except we're keeping line length at 120 (guide says 80)
* Removes version pinning from dependencies that are used for testing/QA

**NB: Can remove `PYTHONUNBUFFERED` variable from Docker Cloud Stackfile after merge**